### PR TITLE
рефакторинг conftest.py и тестов

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,12 +4,11 @@ from methods.create_object import CreateObject
 from methods.delete_object import DeleteObject
 
 
-@pytest.fixture()
+@pytest.fixture(autouse=False)
 def object_id():
     create_object = CreateObject()
     delete_object = DeleteObject()
 
     create_object.create_object()
-    print(create_object.response.json()['id'])
     yield create_object.response.json()['id']
     delete_object.delete_object(create_object.response.json()['id'])

--- a/methods/create_object.py
+++ b/methods/create_object.py
@@ -7,9 +7,9 @@ from models.object_model import CreateObjectModel
 class CreateObject(BaseMethods):
 
     def create_object(self):
-
         self.response = requests.post(
-            url= self.endpoints.ADD_OBJECT,
+            url=self.endpoints.ADD_OBJECT,
             json=self.payloads.new_object
         )
-        CreateObjectModel(**self.response.json())
+        model = CreateObjectModel(**self.response.json())
+        return model.id

--- a/methods/delete_object.py
+++ b/methods/delete_object.py
@@ -1,7 +1,6 @@
 import requests
 
 from methods.base_methods import BaseMethods
-from models.object_model import ObjectModel
 
 
 class DeleteObject(BaseMethods):

--- a/tests/test_create_object.py
+++ b/tests/test_create_object.py
@@ -1,12 +1,13 @@
-import pytest
-
 from tests.base_test import BaseTest
 
 
 class TestCreateObject(BaseTest):
 
-    @pytest.mark.skip("При работе с фикстурой создаёт лишний объект")
     def test_create_object(self):
-        self.create_object.create_object()
+        obj_id = self.create_object.create_object()
         self.create_object.check_response_is_200()
         self.create_object.check_name()
+        self.delete_object.delete_object(obj_id)
+        self.delete_object.check_response_is_200()
+        self.get_object.get_single_object(obj_id)
+        self.get_object.check_response_is_404()

--- a/tests/test_delete_object.py
+++ b/tests/test_delete_object.py
@@ -1,8 +1,11 @@
+import pytest
+
 from tests.base_test import BaseTest
 
 
 class TestDeleteObject(BaseTest):
 
+    @pytest.mark.usefixtures("object_id")
     def test_delete_object(self, object_id):
         self.delete_object.delete_object(object_id)
         self.delete_object.check_response_is_200()

--- a/tests/test_get_object.py
+++ b/tests/test_get_object.py
@@ -5,6 +5,7 @@ from tests.base_test import BaseTest
 
 class TestGetObject(BaseTest):
 
+    @pytest.mark.usefixtures("object_id")
     def test_get_single_object(self, object_id):
         self.get_object.get_single_object(object_id)
         self.get_object.check_response_is_200()


### PR DESCRIPTION
- фикстуре в conftest.py добавлена метка "autouse=False", чтобы использовать фикстура только в тех тестах, где она нужна 
- из test_create_object.py убрана метка "skip" и добавлены методы на удаление и поиск объекта 
- в test_single_object добавлена метка на использование фикстуры 
- в create_object.py добавлено возвращение модели объекта 
- Из delete_object.py убран неиспользовавшийся импорт